### PR TITLE
Switch back to upstream Plogon

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Checkout Plogon
       uses: actions/checkout@v4
       with:
-        repository: redstrate/Plogon # temporarily for API_LEVEL 10
+        repository: goatcorp/Plogon
         path: Plogon
 
     - name: Create required folders


### PR DESCRIPTION
This was temporary while Dalamud wasn't released for 7.0, but this is no longer needed